### PR TITLE
vendor: Remove recursive variable reference in DERPFEST_BUILD_TYPE

### DIFF
--- a/config/version.mk
+++ b/config/version.mk
@@ -4,8 +4,9 @@ DERPFEST_VERSION := 16.0
 DERPFEST_BUILD_DATE := $(shell date -u +%Y%m%d)
 
 # Allow DERPFEST_BUILD_TYPE to be set from the environment, default to Community
-DERPFEST_BUILD_TYPE ?= $(strip $(DERPFEST_BUILD_TYPE))
-ifeq ($(DERPFEST_BUILD_TYPE),)
+ifdef DERPFEST_BUILD_TYPE
+  DERPFEST_BUILD_TYPE := $(strip $(DERPFEST_BUILD_TYPE))
+else
   DERPFEST_BUILD_TYPE := Community
 endif
 


### PR DESCRIPTION
- vendor/lineage/config/version.mk:7: error: Recursive variable "DERPFEST_BUILD_TYPE" references itself (eventually)

The variable was incorrectly referencing itself causing build failure. Now properly checks if defined in environment or defaults to "Community".